### PR TITLE
Override the pin-digests presets from config:best-practices

### DIFF
--- a/default.json
+++ b/default.json
@@ -54,6 +54,20 @@
         "gomodUpdateImportPaths",
         "gomodTidy"
       ]
+    },
+    {
+      "description": "Override the docker:pinDigests preset provided by config:best-practices",
+      "matchDatasources": [
+        "docker"
+      ],
+      "pinDigests": false
+    },
+    {
+      "description": "Override the helpers:pinGitHubActionDigests preset provided by config:best-practices",
+      "matchDepTypes": [
+        "action"
+      ],
+      "pinDigests": false
     }
   ],
   "configMigration": true,


### PR DESCRIPTION
The Renovate configuration `default.json` incorporates a number of Renovate presets, including `config:best-practices`. This preset includes the presets, `docker:pinDigests` and `helpers:pinGitHubActionDigests`, which have the effect of pinning Docker images and GitHub Action images (respectively) using hash digest values. Unfortunately, there doesn't seem to be any nice way to override these presets once they are included, and they seem to take precedence over a subsequently specified `:pinDigestsDisabled`.

This PR adds to `default.json` the raw configurations analogous to `docker:pinDigests` and `helpers:pinGitHubActionDigests` with the opposite configuration value, which does turn off digest-pinning for these two types of references.